### PR TITLE
Support for wordpress_network framework detection

### DIFF
--- a/src/Commands/PegCommand.php
+++ b/src/Commands/PegCommand.php
@@ -17,7 +17,7 @@ class PegCommand extends SSHBaseCommand
     /**
      * @inheritdoc
      */
-    protected $valid_frameworks = ['drupal', 'drupal8', 'wordpress'];
+    protected $valid_frameworks = ['drupal', 'drupal8', 'wordpress', 'wordpress_network'];
 
     /**
      * @inheritdoc
@@ -432,6 +432,7 @@ class PegCommand extends SSHBaseCommand
                 $this->command = 'drush';
                 break;
             case 'wordpress':
+            case 'wordpress_network':
                 $this->command = 'wp';
                 break;
         }


### PR DESCRIPTION
Support for wordpress_network framework detection instead of error: `Cannot determine whether to use drush or wp-cli`